### PR TITLE
fix: make select items to be visible (#7)

### DIFF
--- a/src/components/Select/index.module.css
+++ b/src/components/Select/index.module.css
@@ -20,6 +20,11 @@
   font-size: 0.875rem;
 }
 
+.select option,
+.select optgroup {
+  color: initial;
+}
+
 .labelText {
   font-size: 0.7rem;
   display: block;


### PR DESCRIPTION
## Summary
This PR fixes #7 

![fixed](https://raw.githubusercontent.com/technote-space/screenshots/master/wp-meetup-map/201906211720.png)

* I checked the operation with the following browser
  * Chrome
  * Firefox
